### PR TITLE
Fixed descriptions files being downloaded with special characters

### DIFF
--- a/download_service/url_target.py
+++ b/download_service/url_target.py
@@ -166,7 +166,7 @@ class URLTarget(object):
 
         self.file.saved_to = self._rename_if_exists(self.file.saved_to)
 
-        description = open(self.file.saved_to, 'w+')
+        description = open(self.file.saved_to, 'w+', encoding='utf-8')
         to_save = ""
         if(self.file.text_content is not None):
             to_save = tomd.convert(


### PR DESCRIPTION
Hi, today I tried using your project on Windows 10, however I wasn't able to download some descriptions that contained special characters in it (λ for example).
I specified the encoding when the description file is opened and now it works correctly.