### PR TITLE
(fast and temporary) fix for issue #77

### DIFF
--- a/moodle_dl/moodle_connector/results_handler.py
+++ b/moodle_dl/moodle_connector/results_handler.py
@@ -245,7 +245,8 @@ class ResultsHandler:
             if content_fileurl == '' and module_modname.startswith(('url', 'index_mod', 'cookie_mod')):
                 continue
 
-            if module_modname.startswith('index_mod'):
+            # Add the extention condition to avoid renaming pdf files or other downloaded content from moodle pages.
+            if module_modname.startswith('index_mod') and content_filename.endswith('.html'):
                 content_filename = module_name
 
             hash_description = None


### PR DESCRIPTION
Fix issue #77 by checking the extension before renaming file. This avoid renaming files downloaded from pages and get a lot of files with the same name generating other issues.

This fix may not be completely correct but as long as the fetching system will be rewrited soon it should be ok for the moment.