### PR TITLE
add a select_all (Strg+a) option to the select_multiple in utils.cutie

### DIFF
--- a/moodle_dl/moodle_connector/results_handler.py
+++ b/moodle_dl/moodle_connector/results_handler.py
@@ -269,9 +269,6 @@ class ResultsHandler:
                 m.update(hashable_description.encode('utf-8'))
                 hash_description = m.hexdigest()
 
-            if 'sciebo.de' in content_fileurl:
-                content_fileurl += '/download'
-
             new_file = File(
                 module_id=module_id,
                 section_name=section_name,

--- a/moodle_dl/moodle_connector/results_handler.py
+++ b/moodle_dl/moodle_connector/results_handler.py
@@ -269,6 +269,9 @@ class ResultsHandler:
                 m.update(hashable_description.encode('utf-8'))
                 hash_description = m.hexdigest()
 
+            if 'sciebo.de' in content_fileurl:
+                content_fileurl += '/download'
+
             new_file = File(
                 module_id=module_id,
                 section_name=section_name,

--- a/moodle_dl/utils/cutie.py
+++ b/moodle_dl/utils/cutie.py
@@ -31,6 +31,7 @@ class DefaultKeys:
     Attributes:
         interrupt(List[str]): Keys that cause a keyboard interrupt.
         select(List[str]): Keys that trigger list element selection.
+        select_all(List[str]): Keys that trigger selection of all list elements.
         confirm(List[str]): Keys that trigger list confirmation.
         delete(List[str]): Keys that trigger character deletion.
         down(List[str]): Keys that select the element below.
@@ -39,6 +40,7 @@ class DefaultKeys:
 
     interrupt: List[str] = [readchar.key.CTRL_C, readchar.key.CTRL_D]
     select: List[str] = [readchar.key.SPACE]
+    select_all: List[str] = [readchar.key.CTRL_A]
     confirm: List[str] = [readchar.key.ENTER, readchar.key.CR, readchar.key.LF]
     delete: List[str] = [readchar.key.BACKSPACE]
     down: List[str] = [readchar.key.DOWN, 'j']
@@ -273,6 +275,10 @@ def select_multiple(
                 error_message = f'Must select at most {maximal_count} options'
             else:
                 break
+        elif keypress in DefaultKeys.select_all:
+            for i in range(0, max_index+1):
+                if i not in ticked_indices:
+                    ticked_indices.append(i)
         elif keypress in DefaultKeys.interrupt:
             raise KeyboardInterrupt
     print('\033[1A\033[K', end='', flush=True)


### PR DESCRIPTION
I have added the possibility to select all courses at once with Strg+a. I joined a lot of courses and my screen is not big enough, so for me it is a real nice feature ;)

EDIT: I created a new request, because i have multiple branches for different features/patches now. This PR contains just the select_all part...

just this commit: c3d9591cd66ba165621c26409a81a6a1ef63386e