### PR TITLE
Removing session keys

### DIFF
--- a/moodle_dl/moodle_connector/results_handler.py
+++ b/moodle_dl/moodle_connector/results_handler.py
@@ -130,6 +130,12 @@ class ResultsHandler:
 
         description = re.sub(r'id="[^"]*"', "", description)
         description = re.sub(r"id='[^']*'", "", description)
+        
+        # some folder downloads inside a description file may have some session key inside which will always be different.
+        # remove it, to prevent always tagging this file as "modified".
+        description = re.sub(r'<input type="hidden" name="sesskey" value="[0-9a-zA-Z]*" \/>', "", description)
+        description = re.sub(r"<input type='hidden' name='sesskey' value='[0-9a-zA-Z]*' \/>", "", description)
+        
         return description
 
     def _find_all_urls_in_description(


### PR DESCRIPTION
I've had some issues with .md (description) files being always downloaded again, as those where marked as modified.
Indeed, everytime you access them, the content changes as there is one of those interactive folders inside.
The folder however has some hidden attributes like a session id which will ofc. always be diffrent.

As im running the downloader on a server with E-Mail notifications on, its really annoying to get spammed by mails and moodle-dl (correctly!) created a new file for every new "version" thus creating hundrets of files per day.

Im not that familiar with python but I think I found the correct spot to check this and remove it per regex.

Feedback is welcome!