### PR TITLE
Fix error when there are no courses to manage

### DIFF
--- a/moodle_dl/state_recorder/offline_service.py
+++ b/moodle_dl/state_recorder/offline_service.py
@@ -56,6 +56,10 @@ class OfflineService:
                     courses.append(course)
                     break
 
+        if not courses:
+            print('No files are missing locally but stored in the local database. Nothing to do.')
+            return
+
         print('Choose one of the courses:')
         print('[Confirm your selection with the Enter key]')
         print('')


### PR DESCRIPTION
This prevents moodle-dl throwing an error when the list of courses is empty  