### PR TITLE
Add support for Akari folders

### DIFF
--- a/moodle_dl/moodle_connector/results_handler.py
+++ b/moodle_dl/moodle_connector/results_handler.py
@@ -101,7 +101,7 @@ class ResultsHandler:
                 module_modname = 'cookie_mod-' + module_modname
                 files += self._handle_cookie_mod(section_name, module_name, module_modname, module_id, module_url)
 
-            elif module_modname.startswith(('resource', 'folder', 'url', 'index_mod')):
+            elif module_modname.startswith(('resource', 'folder', 'akarifolder', 'url', 'index_mod')):
                 files += self._handle_files(section_name, module_name, module_modname, module_id, module_contents)
 
             elif module_modname in self.course_fetch_addons:


### PR DESCRIPTION
This is small a change I made to support downloading files from different folder module type. 

From what. understand my instituation uses Akari (https://akarisoftware.com/) to manage a lot of the file uploads, which uses a module type called `akarifolder`. They are pretty much the same as standard folder modules, so adding this change was all that was needed.

This is probably a bit niche, but I thought I'd open a PR in case there was interest.