### PR TITLE
Replace youtube_dl references with yt_dlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ Options can be combined with all the actions mentioned above.
     - Warning: This might lead to security flaws and should only be used in non-production environments.
     - Default: False
 - `--ignore-ytdl-errors`
-    - If this option is set, errors that occur when downloading with the help of Youtube-dl are ignored. Thus, no further attempt will be made to download the file using youtube-dl. 
-    - By default, youtube-dl errors are critical, so the download of the corresponding file will be aborted and when you run moodle-dl again, the download will be repeated.  
-    - You can use this option if a download using youtube-dl fails repeatedly.
+    - If this option is set, errors that occur when downloading with the help of yt-dlp are ignored. Thus, no further attempt will be made to download the file using yt-dlp. 
+    - By default, yt-dlp errors are critical, so the download of the corresponding file will be aborted and when you run moodle-dl again, the download will be repeated.  
+    - You can use this option if a download using yt-dlp fails repeatedly.
 - `--without-downloading-files`
     - This flag is used to skip the downloading of files.
     - This allows the local database to be updated to the latest version of Moodle without having to download all files.

--- a/moodle_dl/config_service/config_helper.py
+++ b/moodle_dl/config_service/config_helper.py
@@ -223,9 +223,9 @@ class ConfigHelper:
             options.update({'cookies_path': None})
 
         try:
-            options.update({'youtube_dl_options': self.get_property('youtube_dl_options')})
+            options.update({'yt_dlp_options': self.get_property('yt_dlp_options')})
         except ValueError:
-            options.update({'youtube_dl_options': {}})
+            options.update({'yt_dlp_options': {}})
 
         try:
             options.update({'videopasswords': self.get_property('videopasswords')})

--- a/moodle_dl/download_service/url_target.py
+++ b/moodle_dl/download_service/url_target.py
@@ -80,7 +80,7 @@ class URLTarget(object):
         self.downloaded = 0
 
         # For yt-dlp errors
-        self.youtube_dl_failed_with_error = False
+        self.yt_dlp_failed_with_error = False
 
     def add_progress(self, count: int, block_size: int, total_size: int):
         """
@@ -252,7 +252,7 @@ class URLTarget(object):
                 return
             # This is a critical error, with high probability the link can be downloaded at a later time.
             logging.error('T%s - yt-dlp Error: %s', self.thread_id, msg)
-            self.url_target.youtube_dl_failed_with_error = True
+            self.url_target.yt_dlp_failed_with_error = True
 
     def yt_hook(self, d):
         downloaded_bytes = d.get('downloaded_bytes', 0)
@@ -308,7 +308,7 @@ class URLTarget(object):
             final_filename = final_filename[rel_pos:]
         self.file.saved_to = final_filename
 
-    def is_blocked_for_youtube_dl(self, url_to_download: str):
+    def is_blocked_for_yt_dlp(self, url_to_download: str):
         url_parsed = urlparse.urlparse(url_to_download)
         if url_parsed.hostname.endswith('youtube.com') and url_parsed.path.startswith('/channel/'):
             # We do not want to download whole channels
@@ -495,7 +495,7 @@ class URLTarget(object):
                 self.success = True
                 return True
 
-        elif isHTML and not self.is_blocked_for_youtube_dl(url_to_download):
+        elif isHTML and not self.is_blocked_for_yt_dlp(url_to_download):
 
             filename_tmpl = self.filename + ' - %(title)s (%(id)s).%(ext)s'
             if self.file.content_type == 'description-url':
@@ -514,8 +514,8 @@ class URLTarget(object):
                 'addmetadata': True,
             }
 
-            youtube_dl_options = self.options.get('youtube_dl_options', {})
-            ydl_opts.update(youtube_dl_options)
+            yt_dlp_options = self.options.get('yt_dlp_options', {})
+            ydl_opts.update(yt_dlp_options)
 
             if cookies_path is not None and os.path.isfile(cookies_path):
                 ydl_opts.update({'cookiefile': cookies_path})
@@ -533,7 +533,7 @@ class URLTarget(object):
                 if idx_pw + 1 <= len(password_list):
                     ydl.params['videopassword'] = password_list[idx_pw]
 
-                self.youtube_dl_failed_with_error = False
+                self.yt_dlp_failed_with_error = False
                 # we restart yt-dlp, so we need to reset the return code
                 ydl._download_retcode = 0  # pylint: disable=protected-access
                 try:
@@ -555,14 +555,14 @@ class URLTarget(object):
                         self.thread_id,
                         e,
                     )
-                    self.youtube_dl_failed_with_error = True
+                    self.yt_dlp_failed_with_error = True
                 idx_pw += 1
                 if idx_pw + 1 > len(password_list):
                     break
 
             # if we want we could save ydl.cookiejar (Also the cookiejar of moodle-dl)
 
-            if self.youtube_dl_failed_with_error is True and not self.options.get('ignore_ytdl_errors', False):
+            if self.yt_dlp_failed_with_error is True and not self.options.get('ignore_ytdl_errors', False):
                 if not delete_if_successful:
                     # cleanup the url-link file
                     try:
@@ -829,7 +829,7 @@ class URLTarget(object):
         self.thread_report[self.thread_id]['extra_totalsize'] = None
         self.thread_report[self.thread_id]['current_url'] = self.file.content_fileurl
         self.thread_report[self.thread_id]['external_dl'] = None
-        self.youtube_dl_failed_with_error = False
+        self.yt_dlp_failed_with_error = False
 
         try:
             logging.debug('T%s - Starting downloading of: %s', self.thread_id, self)

--- a/moodle_dl/download_service/url_target.py
+++ b/moodle_dl/download_service/url_target.py
@@ -79,7 +79,7 @@ class URLTarget(object):
         # Total downloaded.
         self.downloaded = 0
 
-        # For Youtube-dl errors
+        # For yt-dlp errors
         self.youtube_dl_failed_with_error = False
 
     def add_progress(self, count: int, block_size: int, total_size: int):
@@ -208,7 +208,7 @@ class URLTarget(object):
 
     class YtLogger(object):
         """
-        Just a logger for Youtube-DL
+        Just a logger for yt-dlp
         """
 
         def __init__(self, url_target):
@@ -229,29 +229,29 @@ class URLTarget(object):
             if msg.find('ETA') >= 0:
                 return
             msg = self.clean_msg(msg)
-            logging.debug('T%s - youtube-dl Debug: %s', self.thread_id, msg)
+            logging.debug('T%s - yt-dlp Debug: %s', self.thread_id, msg)
             pass
 
         def warning(self, msg):
             msg = self.clean_msg(msg)
             if msg.find('Falling back') >= 0:
-                logging.debug('T%s - youtube-dl Warning: %s', self.thread_id, msg)
+                logging.debug('T%s - yt-dlp Warning: %s', self.thread_id, msg)
                 return
             if msg.find('Requested formats are incompatible for merge') >= 0:
-                logging.debug('T%s - youtube-dl Warning: %s', self.thread_id, msg)
+                logging.debug('T%s - yt-dlp Warning: %s', self.thread_id, msg)
                 return
-            logging.warning('T%s - youtube-dl Warning: %s', self.thread_id, msg)
+            logging.warning('T%s - yt-dlp Warning: %s', self.thread_id, msg)
 
         def error(self, msg):
             msg = self.clean_msg(msg)
             if msg.find('Unsupported URL') >= 0:
-                logging.debug('T%s - youtube-dl Error: %s', self.thread_id, msg)
+                logging.debug('T%s - yt-dlp Error: %s', self.thread_id, msg)
                 return
             if msg.find('no suitable InfoExtractor') >= 0:
-                logging.debug('T%s - youtube-dl Error: %s', self.thread_id, msg)
+                logging.debug('T%s - yt-dlp Error: %s', self.thread_id, msg)
                 return
             # This is a critical error, with high probability the link can be downloaded at a later time.
-            logging.error('T%s - youtube-dl Error: %s', self.thread_id, msg)
+            logging.error('T%s - yt-dlp Error: %s', self.thread_id, msg)
             self.url_target.youtube_dl_failed_with_error = True
 
     def yt_hook(self, d):
@@ -534,7 +534,7 @@ class URLTarget(object):
                     ydl.params['videopassword'] = password_list[idx_pw]
 
                 self.youtube_dl_failed_with_error = False
-                # we restart youtube-dl, so we need to reset the return code
+                # we restart yt-dlp, so we need to reset the return code
                 ydl._download_retcode = 0  # pylint: disable=protected-access
                 try:
                     ydl_results = ydl.download([url_to_download])
@@ -551,7 +551,7 @@ class URLTarget(object):
                         break
                 except Exception as e:
                     logging.error(
-                        'T%s - Youtube-dl failed! Error: %s',
+                        'T%s - yt-dlp failed! Error: %s',
                         self.thread_id,
                         e,
                     )
@@ -569,14 +569,14 @@ class URLTarget(object):
                         os.remove(self.file.saved_to)
                     except OSError as e:
                         logging.warning(
-                            'T%s - Could not delete %s after youtube-dl failed. Error: %s',
+                            'T%s - Could not delete %s after yt-dlp failed. Error: %s',
                             self.thread_id,
                             self.file.saved_to,
                             e,
                         )
                 self.success = False
                 raise RuntimeError(
-                    'Youtube-dl could not download the URL. For details see youtube-dl error messages in the log file. '
+                    'yt-dlp could not download the URL. For details see yt-dlp error messages in the log file. '
                     + 'You can ignore this error by running `moodle-dl --ignore-ytdl-errors` once.'
                 )
 

--- a/moodle_dl/main.py
+++ b/moodle_dl/main.py
@@ -564,9 +564,9 @@ def get_parser():
         '--ignore-ytdl-errors',
         default=False,
         action='store_true',
-        help='If this option is set, errors that occur when downloading with the help of Youtube-dl are ignored. '
-        + 'Thus, no further attempt will be made to download the file using youtube-dl. '
-        + 'By default, youtube-dl errors are critical, so the download of the corresponding file '
+        help='If this option is set, errors that occur when downloading with the help of yt-dlp are ignored. '
+        + 'Thus, no further attempt will be made to download the file using yt-dlp. '
+        + 'By default, yt-dlp errors are critical, so the download of the corresponding file '
         + 'will be aborted and when you run moodle-dl again, the download will be repeated.',
     )
 

--- a/moodle_dl/moodle_connector/results_handler.py
+++ b/moodle_dl/moodle_connector/results_handler.py
@@ -281,7 +281,7 @@ class ResultsHandler:
             if url == '':
                 continue
 
-            # To avoid different encodings and quotes and so that youtube-dl downloads correctly
+            # To avoid different encodings and quotes and so that yt-dlp downloads correctly
             # (See issues #96 and #103), we remove all encodings.
             url = html.unescape(url)
             url = urlparse.unquote(url)


### PR DESCRIPTION
I thought we were still using youtube-dl when we have actually switched to yt-dlp for a while. The error messages and references in code however weren't updated to reflect this.

1. First commit replaces only references in docs, comments and some strings without changing actual code.
2. Second commit replaces some references of variables with appropriate names. Functionality remains unaffected/unchanged.