### PR TITLE
Include data for API calls in URL to maximize compatibility

### DIFF
--- a/moodle_dl/moodle_connector/request_helper.py
+++ b/moodle_dl/moodle_connector/request_helper.py
@@ -164,13 +164,17 @@ class RequestHelper:
         json_result = self._initial_parse(response)
         if self.log_responses and function not in ['tool_mobile_get_autologin_key']:
             with open(self.log_responses_to, 'a', encoding='utf-8') as response_log_file:
-                response_log_file.write(f'URL: {response.url}\n')
+                response_log_file.write(f'URL: {self.censor_secrets(response.url)}\n')
                 response_log_file.write(f'Function: {function}\n\n')
                 response_log_file.write(f'Data: {data}\n\n')
                 response_log_file.write(json.dumps(json_result, indent=4, ensure_ascii=False))
                 response_log_file.write('\n\n\n')
 
         return json_result
+
+    @staticmethod
+    def censor_secrets(text):
+        return re.sub(r'wstoken=\w+', 'wstoken=TOKEN', text)
 
     @staticmethod
     def _get_REST_POST_URL(url_base: str, function: str, token: str, data_obj: {str, str}) -> str:

--- a/moodle_dl/moodle_connector/request_helper.py
+++ b/moodle_dl/moodle_connector/request_helper.py
@@ -138,7 +138,7 @@ class RequestHelper:
             raise ValueError('The required Token is not set!')
 
         data_urlencoded = self._get_POST_DATA(function, self.token, data)
-        url = self._get_REST_POST_URL(self.url_base, function)
+        url = self._get_REST_POST_URL(self.url_base, function, self.token, data)
 
         error_ctr = 0
         maxretries = 5
@@ -173,18 +173,27 @@ class RequestHelper:
         return json_result
 
     @staticmethod
-    def _get_REST_POST_URL(url_base: str, function: str) -> str:
+    def _get_REST_POST_URL(url_base: str, function: str, token: str, data_obj: {str, str}) -> str:
         """
         Generates an URL for a REST-POST request
         @params: The necessary parameters for a REST URL
         @return: A formatted URL
         """
-        url = f'{url_base}webservice/rest/server.php?moodlewsrestformat=json&wsfunction={function}'
+        data = {'moodlewsrestformat': 'json'}
+
+        if data_obj is not None:
+            data.update(data_obj)
+
+        data.update({'wsfunction': function, 'wstoken': token})
+
+        url_parameters = RequestHelper.recursive_urlencode(data)
+
+        url = f'{url_base}webservice/rest/server.php?{url_parameters}'
 
         return url
 
     @staticmethod
-    def _get_POST_DATA(function: str, token: str, data_obj: str) -> str:
+    def _get_POST_DATA(function: str, token: str, data_obj: {str: str}) -> str:
         """
         Generates the data for a REST-POST request
         @params: The necessary parameters for a REST URL


### PR DESCRIPTION
According to the [official moodle api documentation][1] one should include all the necessary parameters for the API call in the URL.
This commit makes it possible to use moodle-dl with the austrian [eduvidual][2] moodle service.

[1]: https://docs.moodle.org/dev/Creating_a_web_service_client#Simple_REST_request_example
[2]: https://www.eduvidual.at/my/