### PR TITLE
Use unverified SSLContext with --skip-cert-verify

### DIFF
--- a/moodle_dl/download_service/url_target.py
+++ b/moodle_dl/download_service/url_target.py
@@ -383,7 +383,7 @@ class URLTarget(object):
         isHTML = False
         new_filename = ""
         total_bytes_estimate = -1
-        session = custom_session()
+        session = custom_session(self.verify_cert)
 
         if cookies_path is not None:
             session.cookies = MozillaCookieJar(cookies_path)
@@ -394,7 +394,6 @@ class URLTarget(object):
             response = session.head(
                 url_to_download,
                 headers=RequestHelper.stdHeader,
-                verify=self.verify_cert,
                 allow_redirects=True,
                 timeout=60,
             )

--- a/moodle_dl/moodle_connector/request_helper.py
+++ b/moodle_dl/moodle_connector/request_helper.py
@@ -74,7 +74,7 @@ class RequestHelper:
         if data is not None:
             data_urlencoded = RequestHelper.recursive_urlencode(data)
 
-        session = custom_session()
+        session = custom_session(self.verify)
 
         if cookie_jar_path is not None:
             session.cookies = MozillaCookieJar(cookie_jar_path)
@@ -83,7 +83,7 @@ class RequestHelper:
                 session.cookies.load(ignore_discard=True, ignore_expires=True)
 
         try:
-            response = session.post(url, data=data_urlencoded, headers=self.stdHeader, verify=self.verify, timeout=60)
+            response = session.post(url, data=data_urlencoded, headers=self.stdHeader, timeout=60)
         except RequestException as error:
             raise ConnectionError(f"Connection error: {str(error)}") from None
 
@@ -104,7 +104,7 @@ class RequestHelper:
         @return: The resulting Response object.
         """
 
-        session = custom_session()
+        session = custom_session(self.verify)
 
         if cookie_jar_path is not None:
             session.cookies = MozillaCookieJar(cookie_jar_path)
@@ -112,7 +112,7 @@ class RequestHelper:
             if os.path.exists(cookie_jar_path):
                 session.cookies.load(ignore_discard=True, ignore_expires=True)
         try:
-            response = session.get(url, headers=self.stdHeader, verify=self.verify, timeout=60)
+            response = session.get(url, headers=self.stdHeader, timeout=60)
         except RequestException as error:
             raise ConnectionError(f"Connection error: {str(error)}") from None
 
@@ -143,11 +143,11 @@ class RequestHelper:
 
         error_ctr = 0
         maxretries = 5
-        session = custom_session()
+        session = custom_session(self.verify)
         while True:
             try:
                 response = session.post(
-                    url, data=data_urlencoded, headers=self.stdHeader, verify=self.verify, timeout=timeout
+                    url, data=data_urlencoded, headers=self.stdHeader, timeout=timeout
                 )
                 break
             except (requests.ConnectionError, requests.Timeout) as error:
@@ -210,13 +210,12 @@ class RequestHelper:
         @return: The JSON response returned by the Moodle System, already
         checked for errors.
         """
-        session = custom_session()
+        session = custom_session(self.verify)
         try:
             response = session.post(
                 f'{self.url_base}login/token.php',
                 data=urllib.parse.urlencode(data),
                 headers=self.stdHeader,
-                verify=self.verify,
                 timeout=60,
             )
         except RequestException as error:
@@ -245,7 +244,8 @@ class RequestHelper:
 
         url = f'{self.url_base}lib/upgrade.txt'
         try:
-            response = requests.get(url, headers=self.stdHeader, verify=self.verify, timeout=60)
+            session = custom_session(self.verify)
+            response = session.get(url, headers=self.stdHeader, timeout=60)
         except RequestException as error:
             raise ConnectionError(f"Connection error: {str(error)}") from None
 

--- a/moodle_dl/moodle_connector/ssl_helper.py
+++ b/moodle_dl/moodle_connector/ssl_helper.py
@@ -26,12 +26,15 @@ def configure_ssl_context(context):
     context.options |= 0x4 # set ssl.OP_LEGACY_SERVER_CONNECT bit (https://bugs.python.org/issue44888)
 
 
-def custom_session():
+def custom_session(verify_cert):
     """
     Defines a new session with custom SSL context to support edge cases with OpenSSL 3.X.X
     """
     session = requests.Session()
-    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    if verify_cert:
+        ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    else:
+        ctx = ssl._create_unverified_context()
     configure_ssl_context(ctx)
     session.mount('https://', CustomHttpAdapter(ctx))
     return session


### PR DESCRIPTION
Using the skip-cert-verify flag sets the verify attribute of the request library function calls to true which conflicts with the default context requested from the SSL library that was introduced in #158. In order to circumvent this issue an unverified SSLContext is used on a conditional basis depending on whether the skip-cert-verify flag is defined.