### PR TITLE
Add type hints to the code base

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Add type hints to the codebase
+758cb15d51e315abedcc0d95be34ca65af85370f

--- a/moodle_dl/config_service/config_helper.py
+++ b/moodle_dl/config_service/config_helper.py
@@ -2,6 +2,7 @@ import os
 import json
 
 from pathlib import Path
+from typing import Dict, List
 
 
 class ConfigHelper:
@@ -160,28 +161,28 @@ class ConfigHelper:
         except ValueError:
             raise ValueError('Not yet configured!')
 
-    def get_options_of_courses(self) -> {}:
+    def get_options_of_courses(self) -> Dict:
         # returns a stored dictionary of options for courses
         try:
             return self.get_property('options_of_courses')
         except ValueError:
             return {}
 
-    def get_dont_download_course_ids(self) -> []:
+    def get_dont_download_course_ids(self) -> List:
         # returns a stored list of ids that should not be downloaded
         try:
             return self.get_property('dont_download_course_ids')
         except ValueError:
             return []
 
-    def get_download_linked_files(self) -> {}:
+    def get_download_linked_files(self) -> Dict:
         # returns if linked files should be downloaded
         try:
             return self.get_property('download_linked_files')
         except ValueError:
             return False
 
-    def get_exclude_file_extensions(self) -> {}:
+    def get_exclude_file_extensions(self) -> Dict:
         # returns a list of file extensions that should not be downloaded
         try:
             exclude_file_extensions = self.get_property('exclude_file_extensions')
@@ -191,14 +192,14 @@ class ConfigHelper:
         except ValueError:
             return []
 
-    def get_download_also_with_cookie(self) -> {}:
+    def get_download_also_with_cookie(self) -> Dict:
         # returns if files for which a cookie is required should be downloaded
         try:
             return self.get_property('download_also_with_cookie')
         except ValueError:
             return False
 
-    def get_download_options(self) -> {}:
+    def get_download_options(self) -> Dict:
         # returns the option dictionary for downloading files
         options = {}
         try:
@@ -239,7 +240,7 @@ class ConfigHelper:
 
         return options
 
-    def get_restricted_filenames(self) -> {}:
+    def get_restricted_filenames(self) -> Dict:
         # returns the filenames should be restricted
         try:
             return self.get_property('restricted_filenames')

--- a/moodle_dl/config_service/config_service.py
+++ b/moodle_dl/config_service/config_service.py
@@ -2,6 +2,7 @@ import sys
 import shutil
 
 from pathlib import Path
+from typing import Dict, List
 
 from moodle_dl.utils import cutie
 from moodle_dl.utils.logger import Log
@@ -179,7 +180,7 @@ class ConfigService:
 
         self.section_seperator()
 
-    def _select_courses_to_download(self, courses: [Course]):
+    def _select_courses_to_download(self, courses: List[Course]):
         """
         Asks the user for the courses that should be downloaded.
         @param courses: All available courses
@@ -241,7 +242,7 @@ class ConfigService:
             self.config_helper.set_property('dont_download_course_ids', course_ids)
             self.config_helper.remove_property('download_course_ids')
 
-    def _select_sections_to_download(self, sections: [{}], excluded: [int]) -> [int]:
+    def _select_sections_to_download(self, sections: List[Dict], excluded: List[int]) -> List[int]:
         """
         Asks the user for the sections that should be downloaded.
         @param sections: All available sections
@@ -269,7 +270,7 @@ class ConfigService:
 
         return dont_download_section_ids
 
-    def _set_options_of_courses(self, courses: [Course]):
+    def _set_options_of_courses(self, courses: List[Course]):
         """
         Let the user set special options for every single course
         """
@@ -340,7 +341,7 @@ class ConfigService:
                 sel = choices_courses[selected_course - 1]
                 self._change_settings_of(sel, options_of_courses)
 
-    def _change_settings_of(self, course: Course, options_of_courses: {}):
+    def _change_settings_of(self, course: Course, options_of_courses: Dict):
         """
         Ask for a new Name for the course.
         Then asks if a file structure should be created.

--- a/moodle_dl/download_service/download_service.py
+++ b/moodle_dl/download_service/download_service.py
@@ -6,6 +6,7 @@ import shutil
 import logging
 import threading
 from queue import Queue
+from typing import List
 import certifi
 
 from yt_dlp.utils import format_bytes
@@ -30,7 +31,7 @@ class DownloadService:
 
     def __init__(
         self,
-        courses: [Course],
+        courses: List[Course],
         moodle_service: MoodleService,
         storage_path: str,
         skip_cert_verify: bool = False,

--- a/moodle_dl/download_service/downloader.py
+++ b/moodle_dl/download_service/downloader.py
@@ -2,6 +2,7 @@ import logging
 import threading
 
 from queue import Queue, Empty
+from typing import List
 
 from moodle_dl.state_recorder.state_recorder import StateRecorder
 
@@ -15,7 +16,7 @@ class Downloader(threading.Thread):
     def __init__(
         self,
         queue: Queue,
-        report: [],
+        report: List,
         state_recorder: StateRecorder,
         thread_id: int,
         db_lock: threading.Lock,

--- a/moodle_dl/download_service/fake_download_service.py
+++ b/moodle_dl/download_service/fake_download_service.py
@@ -2,6 +2,7 @@ import os
 import platform
 
 from pathlib import Path
+from typing import List
 
 from moodle_dl.utils.logger import Log
 from moodle_dl.state_recorder.course import Course
@@ -17,7 +18,7 @@ class FakeDownloadService:
     can be created without actually downloading the files.
     """
 
-    def __init__(self, courses: [Course], moodle_service: MoodleService, storage_path: str):
+    def __init__(self, courses: List[Course], moodle_service: MoodleService, storage_path: str):
         """
         Initiates the FakeDownloadService with all files that
         need to be downloaded (saved in the database).

--- a/moodle_dl/download_service/url_target.py
+++ b/moodle_dl/download_service/url_target.py
@@ -6,6 +6,7 @@ import time
 import shlex
 import socket
 import shutil
+from typing import Dict, List
 import urllib
 import logging
 import posixpath
@@ -46,11 +47,11 @@ class URLTarget(object):
         course: Course,
         destination: str,
         token: str,
-        thread_report: [],
+        thread_report: List,
         fs_lock: threading.Lock,
         ssl_context: ssl.SSLContext,
         skip_cert_verify: bool,
-        options: {},
+        options: Dict,
     ):
         """
         Initiating an URL target.

--- a/moodle_dl/moodle_connector/assignments_handler.py
+++ b/moodle_dl/moodle_connector/assignments_handler.py
@@ -1,3 +1,4 @@
+from typing import Dict, List
 from moodle_dl.state_recorder.course import Course
 from moodle_dl.moodle_connector.request_helper import RequestHelper
 
@@ -11,7 +12,7 @@ class AssignmentsHandler:
         self.request_helper = request_helper
         self.version = version
 
-    def fetch_assignments(self, courses: [Course]) -> {int: {int: {}}}:
+    def fetch_assignments(self, courses: List[Course]) -> Dict[int, Dict[int, Dict]]:
         """
         Fetches the Assignments List for all courses from the
         Moodle system
@@ -85,7 +86,7 @@ class AssignmentsHandler:
 
         return result
 
-    def fetch_submissions(self, userid: int, assignments: {int: {int: {}}}) -> {int: {int: {}}}:
+    def fetch_submissions(self, userid: int, assignments: Dict[int, Dict[int, Dict]]) -> Dict[int, Dict[int, Dict]]:
         """
         Fetches for the assignments list of all courses the additionally
         submissions. This is kind of waste of resources, because there
@@ -137,7 +138,7 @@ class AssignmentsHandler:
         return assignments
 
     @staticmethod
-    def _get_files_of_submission(submission: {}) -> []:
+    def _get_files_of_submission(submission: Dict) -> List:
         result = []
         # get own submissions
         lastattempt = submission.get('lastattempt', {})
@@ -155,7 +156,7 @@ class AssignmentsHandler:
         return result
 
     @staticmethod
-    def _get_grade_of_feedback(feedback: {}) -> []:
+    def _get_grade_of_feedback(feedback: Dict) -> List:
         result = []
 
         gradefordisplay = feedback.get('gradefordisplay', "")
@@ -176,7 +177,7 @@ class AssignmentsHandler:
         return result
 
     @staticmethod
-    def _get_files_of_plugins(obj: {}) -> []:
+    def _get_files_of_plugins(obj: Dict) -> List:
         result = []
         plugins = obj.get('plugins', [])
 

--- a/moodle_dl/moodle_connector/databases_handler.py
+++ b/moodle_dl/moodle_connector/databases_handler.py
@@ -1,3 +1,4 @@
+from typing import Dict, List
 from moodle_dl.moodle_connector.request_helper import RequestHelper
 from moodle_dl.state_recorder.course import Course
 
@@ -11,7 +12,7 @@ class DatabasesHandler:
         self.request_helper = request_helper
         self.version = version
 
-    def fetch_databases(self, courses: [Course]) -> {int: {int: {}}}:
+    def fetch_databases(self, courses: List[Course]) -> Dict[int, Dict[int, Dict]]:
         """
         Fetches the Databases List for all courses from the
         Moodle system
@@ -80,7 +81,7 @@ class DatabasesHandler:
 
         return result
 
-    def fetch_database_files(self, databases: {int: {int: {}}}) -> {int: {int: {}}}:
+    def fetch_database_files(self, databases: Dict[int, Dict[int, Dict]]) -> Dict[int, Dict[int, Dict]]:
         """
         Fetches for the databases list of all courses the additionally
         entries. This is kind of waste of resources, because there
@@ -126,7 +127,7 @@ class DatabasesHandler:
         return databases
 
     @staticmethod
-    def _get_files_of_db_entries(entries: {}) -> []:
+    def _get_files_of_db_entries(entries: Dict) -> List:
         result = []
 
         entries_list = entries.get('entries', [])

--- a/moodle_dl/moodle_connector/first_contact_handler.py
+++ b/moodle_dl/moodle_connector/first_contact_handler.py
@@ -1,4 +1,5 @@
 import json
+from typing import Dict, List
 
 from moodle_dl.moodle_connector.request_helper import RequestHelper
 from moodle_dl.state_recorder.course import Course
@@ -35,7 +36,7 @@ class FirstContactHandler:
         self.version = version
         return userid, version
 
-    def fetch_courses(self, userid: str) -> [Course]:
+    def fetch_courses(self, userid: str) -> List[Course]:
         """
         Queries the Moodle system for all courses the user
         is enrolled in.
@@ -52,7 +53,7 @@ class FirstContactHandler:
             # We could also extract here the course summary and intro files
         return results
 
-    def fetch_all_visible_courses(self, log_all_courses_to: str = None) -> [Course]:
+    def fetch_all_visible_courses(self, log_all_courses_to: str = None) -> List[Course]:
         """
         Queries the Moodle system for all courses available on the system and returns:
         @return: A list of all visible courses
@@ -73,7 +74,7 @@ class FirstContactHandler:
                 results.append(Course(course.get('id', 0), course.get('fullname', '')))
         return results
 
-    def fetch_courses_info(self, course_ids: [int]) -> [Course]:
+    def fetch_courses_info(self, course_ids: List[int]) -> List[Course]:
         """
         Queries the Moodle system for info about courses in a list.
         @param course_ids: A list of courses ids
@@ -97,7 +98,7 @@ class FirstContactHandler:
             # We could also extract here the course summary and intro files
         return results
 
-    def fetch_sections(self, course_id: int) -> [{}]:
+    def fetch_sections(self, course_id: int) -> List[Dict]:
         """
         Fetches the Sections List for a course from the Moodle system
         @param course_id: The id of the requested course.

--- a/moodle_dl/moodle_connector/folders_handler.py
+++ b/moodle_dl/moodle_connector/folders_handler.py
@@ -1,3 +1,4 @@
+from typing import List
 from moodle_dl.state_recorder.course import Course
 from moodle_dl.moodle_connector.request_helper import RequestHelper
 
@@ -11,7 +12,7 @@ class FoldersHandler:
         self.request_helper = request_helper
         self.version = version
 
-    def fetch_folders(self, courses: [Course]) -> {int: {int: {}}}:
+    def fetch_folders(self, courses: List[Course]) -> {int: {int: {}}}:
         """
         Fetches the Folder List for all courses from the
         Moodle system

--- a/moodle_dl/moodle_connector/forums_handler.py
+++ b/moodle_dl/moodle_connector/forums_handler.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Dict, List
 
 from moodle_dl.moodle_connector.request_helper import RequestHelper
 from moodle_dl.state_recorder.course import Course
@@ -14,7 +15,7 @@ class ForumsHandler:
         self.request_helper = request_helper
         self.version = version
 
-    def fetch_forums(self, courses: [Course]) -> {int: {int: {}}}:
+    def fetch_forums(self, courses: List[Course]) -> Dict[int, Dict[int, Dict]]:
         """
         Fetches the Databases List for all courses from the
         Moodle system
@@ -81,7 +82,7 @@ class ForumsHandler:
 
         return result
 
-    def fetch_forums_posts(self, forums: {}, last_timestamps_per_forum: {}) -> {}:
+    def fetch_forums_posts(self, forums: Dict, last_timestamps_per_forum: Dict) -> Dict:
         """
         Fetches for the forums list of all courses the additionally
         entries. This is kind of waste of resources, because there
@@ -165,7 +166,7 @@ class ForumsHandler:
 
         return forums
 
-    def _get_files_of_discussions(self, latest_discussions: []) -> []:
+    def _get_files_of_discussions(self, latest_discussions: List) -> List:
         result = []
 
         for counter, discussion in enumerate(latest_discussions):

--- a/moodle_dl/moodle_connector/lessons_handler.py
+++ b/moodle_dl/moodle_connector/lessons_handler.py
@@ -1,4 +1,5 @@
 import re
+from typing import Dict, List
 
 from moodle_dl.moodle_connector.request_helper import RequestHelper, RequestRejectedError
 from moodle_dl.state_recorder.course import Course
@@ -15,7 +16,7 @@ class LessonsHandler:
         self.request_helper = request_helper
         self.version = version
 
-    def fetch_lessons(self, courses: [Course]) -> {int: {int: {}}}:
+    def fetch_lessons(self, courses: List[Course]) -> Dict[int,Dict[int,Dict]]:
         """
         Fetches the Lessons List for all courses from the
         Moodle system
@@ -85,7 +86,7 @@ class LessonsHandler:
 
         return result
 
-    def fetch_lessons_files(self, userid: int, lessons: {}) -> {}:
+    def fetch_lessons_files(self, userid: int, lessons: Dict) -> Dict:
         """
         Fetches for the lessons list of all courses the additionally
         entries. This is kind of waste of resources, because there
@@ -138,7 +139,7 @@ class LessonsHandler:
 
         return lessons
 
-    def _get_files_of_attempt(self, attempt_result: {}, lesson_name: str) -> []:
+    def _get_files_of_attempt(self, attempt_result: Dict, lesson_name: str) -> List:
         result = []
 
         answerpages = attempt_result.get('answerpages', [])

--- a/moodle_dl/moodle_connector/moodle_service.py
+++ b/moodle_dl/moodle_connector/moodle_service.py
@@ -4,6 +4,7 @@ import logging
 
 from pathlib import Path
 from getpass import getpass
+from typing import List
 from urllib.parse import urlparse
 from distutils.version import StrictVersion
 
@@ -249,7 +250,7 @@ class MoodleService:
 
         return moodle_token
 
-    def fetch_state(self) -> [Course]:
+    def fetch_state(self) -> List[Course]:
         """
         Gets the current status of the configured Moodle account and compares
         it with the last known status for changes. It does not change the
@@ -399,7 +400,7 @@ class MoodleService:
 
         return changes
 
-    def add_options_to_courses(self, courses: [Course]):
+    def add_options_to_courses(self, courses: List[Course]):
         """
         Updates a array of courses with its options
         """
@@ -415,11 +416,11 @@ class MoodleService:
 
     @staticmethod
     def filter_courses(
-        changes: [Course],
+        changes: List[Course],
         config_helper: ConfigHelper,
         cookie_handler: CookieHandler = None,
-        courses_list: [Course] = None,
-    ) -> [Course]:
+        courses_list: List[Course] = None,
+    ) -> List[Course]:
         """
         Filters the changes course list from courses that
         should not get downloaded

--- a/moodle_dl/moodle_connector/pages_handler.py
+++ b/moodle_dl/moodle_connector/pages_handler.py
@@ -1,3 +1,4 @@
+from typing import Dict, List
 from moodle_dl.state_recorder.course import Course
 from moodle_dl.moodle_connector.request_helper import RequestHelper
 
@@ -11,7 +12,7 @@ class PagesHandler:
         self.request_helper = request_helper
         self.version = version
 
-    def fetch_pages(self, courses: [Course]) -> {int: {int: {}}}:
+    def fetch_pages(self, courses: List[Course]) -> {int: {int: Dict}}:
         """
         Fetches the Pages List for all courses from the
         Moodle system

--- a/moodle_dl/moodle_connector/quizzes_handler.py
+++ b/moodle_dl/moodle_connector/quizzes_handler.py
@@ -1,3 +1,4 @@
+from typing import Dict, List
 from moodle_dl.moodle_connector.request_helper import RequestHelper, RequestRejectedError
 from moodle_dl.state_recorder.course import Course
 from moodle_dl.download_service.path_tools import PathTools
@@ -13,7 +14,7 @@ class QuizzesHandler:
         self.request_helper = request_helper
         self.version = version
 
-    def fetch_quizzes(self, courses: [Course]) -> {int: {int: {}}}:
+    def fetch_quizzes(self, courses: List[Course]) -> Dict[int, Dict[int, Dict]]:
         """
         Fetches the Quizzes List for all courses from the
         Moodle system
@@ -82,7 +83,7 @@ class QuizzesHandler:
 
         return result
 
-    def fetch_quizzes_files(self, userid: int, quizzes: {}) -> {}:
+    def fetch_quizzes_files(self, userid: int, quizzes: Dict) -> Dict:
         """
         Fetches for the quizzes list of all courses the additionally
         entries. This is kind of waste of resources, because there
@@ -133,7 +134,7 @@ class QuizzesHandler:
 
         return quizzes
 
-    def _get_files_of_attempts(self, attempts: [], quiz_name: str) -> []:
+    def _get_files_of_attempts(self, attempts: List, quiz_name: str) -> List:
         result = []
 
         for attempt in attempts:

--- a/moodle_dl/moodle_connector/results_handler.py
+++ b/moodle_dl/moodle_connector/results_handler.py
@@ -2,6 +2,7 @@ import re
 import html
 import logging
 import hashlib
+from typing import Dict, List
 import urllib.parse as urlparse
 
 from moodle_dl.state_recorder.course import Course
@@ -28,7 +29,9 @@ class ResultsHandler:
         logging.debug('Detected moodle version: %d', version)
 
     @staticmethod
-    def should_download_course(course_id: int, download_course_ids: [int], dont_download_course_ids: [int]) -> bool:
+    def should_download_course(
+        course_id: int, download_course_ids: List[int], dont_download_course_ids: List[int]
+    ) -> bool:
         """
         Checks if a course is in White-list and not in Blacklist
         """
@@ -38,14 +41,14 @@ class ResultsHandler:
         return inWhitelist and not inBlacklist
 
     @staticmethod
-    def should_download_section(section_id: int, dont_download_sections_ids: [int]) -> bool:
+    def should_download_section(section_id: int, dont_download_sections_ids: List[int]) -> bool:
         """
         Checks if a section is not in Blacklist
         """
 
         return section_id not in dont_download_sections_ids or len(dont_download_sections_ids) == 0
 
-    def _get_files_in_sections(self, course_sections: []) -> [File]:
+    def _get_files_in_sections(self, course_sections: List) -> List[File]:
         """
         Iterates over all sections of a course to find files (or modules).
         @param course_sections: The course object returned by Moodle,
@@ -69,7 +72,7 @@ class ResultsHandler:
 
         return files
 
-    def _get_files_in_modules(self, section_name: str, section_id: int, section_modules: []) -> [File]:
+    def _get_files_in_modules(self, section_name: str, section_id: int, section_modules: List) -> List[File]:
         """
         Iterates over all modules to find files (or content) in them.
         @param section_name: The name of the section to be iterated over.
@@ -253,8 +256,8 @@ class ResultsHandler:
         content_filepath: str,
         content_html: str,
         no_search_for_moodle_urls: bool,
-        filter_urls_containing: [str],
-    ) -> [File]:
+        filter_urls_containing: List[str],
+    ) -> List[File]:
         """Parses a html string to find all urls in it. Then it creates for every url a file entry.
 
         Args:
@@ -346,7 +349,7 @@ class ResultsHandler:
 
     def _handle_cookie_mod(
         self, section_name: str, section_id: int, module_name: str, module_modname: str, module_id: str, module_url: str
-    ) -> [File]:
+    ) -> List[File]:
         """
         Creates a list of files out of a cookie module
         @param module_url: The url to the cookie module.
@@ -380,8 +383,8 @@ class ResultsHandler:
         module_name: str,
         module_modname: str,
         module_id: str,
-        module_contents: [],
-    ) -> [File]:
+        module_contents: List,
+    ) -> List[File]:
         """
         Iterates over all files that are in a module or assignment and
         returns a list of all files
@@ -472,7 +475,7 @@ class ResultsHandler:
         module_modname: str,
         module_id: str,
         module_description: str,
-    ) -> [File]:
+    ) -> List[File]:
         """
         Creates a description file
         @param module_description: The description of the module
@@ -532,7 +535,7 @@ class ResultsHandler:
 
         return files
 
-    def set_fetch_addons(self, course_fetch_addons: {}):
+    def set_fetch_addons(self, course_fetch_addons: Dict):
         """
         Sets the optional data that will be added to the result list
          during the process.
@@ -541,7 +544,7 @@ class ResultsHandler:
         """
         self.course_fetch_addons = course_fetch_addons
 
-    def fetch_files(self, course: Course) -> [File]:
+    def fetch_files(self, course: Course) -> List[File]:
         """
         Queries the Moodle system for all the files that
         are present in a course

--- a/moodle_dl/moodle_connector/workshops_handler.py
+++ b/moodle_dl/moodle_connector/workshops_handler.py
@@ -1,3 +1,4 @@
+from typing import Dict, List
 from moodle_dl.moodle_connector.request_helper import RequestHelper, RequestRejectedError
 from moodle_dl.state_recorder.course import Course
 
@@ -11,7 +12,7 @@ class WorkshopsHandler:
         self.request_helper = request_helper
         self.version = version
 
-    def fetch_workshops(self, courses: [Course]) -> {int: {int: {}}}:
+    def fetch_workshops(self, courses: List[Course]) -> Dict[int, Dict[int, Dict]]:
         """
         Fetches the Workshops List for all courses from the
         Moodle system
@@ -116,7 +117,7 @@ class WorkshopsHandler:
 
         return result
 
-    def fetch_workshops_files(self, userid: int, workshops: {}) -> {}:
+    def fetch_workshops_files(self, userid: int, workshops: Dict) -> Dict:
         """
         Fetches for the workshops list of all courses the additionally
         entries. This is kind of waste of resources, because there
@@ -183,7 +184,9 @@ class WorkshopsHandler:
 
         return workshops
 
-    def _get_files_of_workshop(self, submissions_result: {}, reviewer_assessments_result: {}, grades_result: {}) -> []:
+    def _get_files_of_workshop(
+        self, submissions_result: Dict, reviewer_assessments_result: Dict, grades_result: Dict
+    ) -> List:
         result = []
 
         submissions = submissions_result.get('submissions', [])

--- a/moodle_dl/notification_services/console/console_service.py
+++ b/moodle_dl/notification_services/console/console_service.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 from moodle_dl.utils.logger import Log
 from moodle_dl.state_recorder.course import Course
@@ -10,7 +11,7 @@ class ConsoleService(NotificationService):
     def interactively_configure(self) -> None:
         raise RuntimeError('Not yet implemendet!')
 
-    def notify_about_changes_in_moodle(self, changes: [Course]) -> None:
+    def notify_about_changes_in_moodle(self, changes: List[Course]) -> None:
         """
         Creates a terminal output about the downloaded changes.
         @param changes: A list of changed courses with changed files.
@@ -62,7 +63,7 @@ class ConsoleService(NotificationService):
     def notify_about_error(self, error_description: str):
         Log.error(f'The following error occurred during execution:\n{error_description}')
 
-    def notify_about_failed_downloads(self, failed_downloads: [URLTarget]):
+    def notify_about_failed_downloads(self, failed_downloads: List[URLTarget]):
         if len(failed_downloads) > 0:
             print('')
             Log.warning(

--- a/moodle_dl/notification_services/mail/mail_service.py
+++ b/moodle_dl/notification_services/mail/mail_service.py
@@ -2,6 +2,7 @@ import logging
 import traceback
 
 from getpass import getpass
+from typing import List
 
 from moodle_dl.utils import cutie
 from moodle_dl.utils.logger import Log
@@ -110,7 +111,7 @@ class MailService(NotificationService):
             logging.error('While sending notification:\n%s', error_formatted, extra={'exception': e})
             raise e  # to be properly notified via Sentry
 
-    def notify_about_changes_in_moodle(self, changes: [Course]) -> None:
+    def notify_about_changes_in_moodle(self, changes: List[Course]) -> None:
         """
         Sends out a notification email about the downloaded changes.
         @param changes: A list of changed courses with changed files.
@@ -142,7 +143,7 @@ class MailService(NotificationService):
         mail_content = create_full_error_mail(error_description)
         self._send_mail('Error!', mail_content)
 
-    def notify_about_failed_downloads(self, failed_downloads: [URLTarget]):
+    def notify_about_failed_downloads(self, failed_downloads: List[URLTarget]):
         """
         Sends out an mail with all failed download if configured to send out error messages.
         @param failed_downloads: A list of failed URLTargets.

--- a/moodle_dl/notification_services/notification_service.py
+++ b/moodle_dl/notification_services/notification_service.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from typing import List
 
 from moodle_dl.state_recorder.course import Course
 from moodle_dl.download_service.url_target import URLTarget
@@ -23,7 +24,7 @@ class NotificationService:
         pass
 
     @abstractmethod
-    def notify_about_changes_in_moodle(self, changes: [Course]) -> None:
+    def notify_about_changes_in_moodle(self, changes: List[Course]) -> None:
         """
         Sends out a Notification to inform about detected changes for the
         Moodle-Account. The caller shouldn't care about if the sending was
@@ -43,7 +44,7 @@ class NotificationService:
         pass
 
     @abstractmethod
-    def notify_about_failed_downloads(self, failed_downloads: [URLTarget]) -> None:
+    def notify_about_failed_downloads(self, failed_downloads: List[URLTarget]) -> None:
         """
         Sends out a Notification to inform about failed downloads encountered during
         the execution of the program.

--- a/moodle_dl/notification_services/telegram/telegram_formater.py
+++ b/moodle_dl/notification_services/telegram/telegram_formater.py
@@ -1,4 +1,5 @@
 import re
+from typing import List
 
 import html2text
 
@@ -8,7 +9,7 @@ from moodle_dl.download_service.url_target import URLTarget
 
 class TelegramFormater:
     @staticmethod
-    def append_with_limit(new_line: str, one_msg_content: str, msg_list: [str]):
+    def append_with_limit(new_line: str, one_msg_content: str, msg_list: List[str]):
         """Appends a new line to a message string,
         if the string is to long it ist appended to the message list.
         Returns the new message string.
@@ -37,7 +38,7 @@ class TelegramFormater:
         return '<b>' + string + '</b>'
 
     @classmethod
-    def create_full_moodle_diff_messages(cls, changed_courses: [Course]) -> [str]:
+    def create_full_moodle_diff_messages(cls, changed_courses: List[Course]) -> List[str]:
         """
         Creates telegram messages with all changed files. This includes new,
         modified and deleted files. Files that have changed since the last message.
@@ -102,7 +103,7 @@ class TelegramFormater:
         return result_list
 
     @classmethod
-    def create_full_error_messages(cls, details) -> [str]:
+    def create_full_error_messages(cls, details) -> List[str]:
         """
         Creates error messages
         """
@@ -117,7 +118,7 @@ class TelegramFormater:
         return result_list
 
     @classmethod
-    def create_full_failed_downloads_messages(cls, failed_downloads: [URLTarget]) -> [str]:
+    def create_full_failed_downloads_messages(cls, failed_downloads: List[URLTarget]) -> List[str]:
         """
         Creates messages with all failed downloads
         """

--- a/moodle_dl/notification_services/telegram/telegram_service.py
+++ b/moodle_dl/notification_services/telegram/telegram_service.py
@@ -1,5 +1,6 @@
 import logging
 import traceback
+from typing import List
 
 from moodle_dl.utils import cutie
 from moodle_dl.utils.logger import Log
@@ -71,7 +72,7 @@ class TelegramService(NotificationService):
             logging.debug('Telegram-Notifications not configured, skipping.')
             return False
 
-    def _send_messages(self, messages: [str]):
+    def _send_messages(self, messages: List[str]):
         """
         Sends an message
         """
@@ -93,7 +94,7 @@ class TelegramService(NotificationService):
                 logging.error('While sending notification:\n%s', error_formatted, extra={'exception': e})
                 raise e  # to be properly notified via Sentry
 
-    def notify_about_changes_in_moodle(self, changes: [Course]) -> None:
+    def notify_about_changes_in_moodle(self, changes: List[Course]) -> None:
         """
         Sends out a notification about the downloaded changes.
         @param changes: A list of changed courses with changed files.
@@ -121,7 +122,7 @@ class TelegramService(NotificationService):
 
         self._send_messages(messages)
 
-    def notify_about_failed_downloads(self, failed_downloads: [URLTarget]):
+    def notify_about_failed_downloads(self, failed_downloads: List[URLTarget]):
         """
         Sends out an message about failed download if configured to send out error messages.
         @param failed_downloads: A list of failed URLTargets.

--- a/moodle_dl/notification_services/xmpp/xmpp_formater.py
+++ b/moodle_dl/notification_services/xmpp/xmpp_formater.py
@@ -1,9 +1,10 @@
+from typing import List
 from moodle_dl.notification_services.telegram.telegram_formater import TelegramFormater
 
 
 class XmppFormater(TelegramFormater):
     @staticmethod
-    def append_with_limit(new_line: str, one_msg_content: str, msg_list: [str]):
+    def append_with_limit(new_line: str, one_msg_content: str, msg_list: List[str]):
         """Appends a new line to a message string,
         if the string is to long it ist appended to the message list.
         Returns the new message string.

--- a/moodle_dl/notification_services/xmpp/xmpp_service.py
+++ b/moodle_dl/notification_services/xmpp/xmpp_service.py
@@ -2,6 +2,7 @@ import logging
 import traceback
 
 from getpass import getpass
+from typing import List
 
 import aioxmpp
 
@@ -78,7 +79,7 @@ class XmppService(NotificationService):
             logging.debug('XMPP-Notifications not configured, skipping.')
             return False
 
-    def _send_messages(self, messages: [str]):
+    def _send_messages(self, messages: List[str]):
         """
         Sends an message
         """
@@ -98,7 +99,7 @@ class XmppService(NotificationService):
             logging.error('While sending notification:\n%s', error_formatted, extra={'exception': e})
             raise e  # to be properly notified via Sentry
 
-    def notify_about_changes_in_moodle(self, changes: [Course]) -> None:
+    def notify_about_changes_in_moodle(self, changes: List[Course]) -> None:
         """
         Sends out a notification about the downloaded changes.
         @param changes: A list of changed courses with changed files.
@@ -126,7 +127,7 @@ class XmppService(NotificationService):
 
         self._send_messages(messages)
 
-    def notify_about_failed_downloads(self, failed_downloads: [URLTarget]):
+    def notify_about_failed_downloads(self, failed_downloads: List[URLTarget]):
         """
         Sends out an message about failed download if configured to send out error messages.
         @param failed_downloads: A list of failed URLTargets.

--- a/moodle_dl/state_recorder/course.py
+++ b/moodle_dl/state_recorder/course.py
@@ -1,9 +1,10 @@
+from typing import List
 from moodle_dl.state_recorder.file import File
 from moodle_dl.download_service.path_tools import PathTools
 
 
 class Course:
-    def __init__(self, _id: int, fullname: str, files: [File] = None):
+    def __init__(self, _id: int, fullname: str, files: List[File] = None):
         self.id = _id
         self.fullname = PathTools.to_valid_name(fullname)
         if files is not None:

--- a/moodle_dl/state_recorder/state_recorder.py
+++ b/moodle_dl/state_recorder/state_recorder.py
@@ -2,6 +2,7 @@ import sqlite3
 import logging
 
 from sqlite3 import Error
+from typing import Dict, List
 
 from moodle_dl.state_recorder.file import File
 from moodle_dl.state_recorder.course import Course
@@ -262,7 +263,7 @@ class StateRecorder:
 
         return False
 
-    def get_stored_files(self) -> [Course]:
+    def get_stored_files(self) -> List[Course]:
         # get all stored files (that are not yet deleted)
         conn = sqlite3.connect(self.db_file)
         conn.row_factory = sqlite3.Row
@@ -303,7 +304,7 @@ class StateRecorder:
         conn.close()
         return stored_courses
 
-    def get_old_files(self) -> [Course]:
+    def get_old_files(self) -> List[Course]:
         # get all stored files (that are not yet deleted)
         conn = sqlite3.connect(self.db_file)
         conn.row_factory = sqlite3.Row
@@ -349,7 +350,7 @@ class StateRecorder:
         conn.close()
         return stored_courses
 
-    def __get_modified_files(self, stored_courses: [Course], current_courses: [Course]) -> [Course]:
+    def __get_modified_files(self, stored_courses: List[Course], current_courses: List[Course]) -> List[Course]:
         # returns courses with modified and deleted files
         changed_courses = []
 
@@ -426,8 +427,8 @@ class StateRecorder:
         return changed_courses
 
     def __get_new_files(
-        self, changed_courses: [Course], stored_courses: [Course], current_courses: [Course]
-    ) -> [Course]:
+        self, changed_courses: List[Course], stored_courses: List[Course], current_courses: List[Course]
+    ) -> List[Course]:
         # check for new files
         for current_course in current_courses:
             # check if that file does not exist in stored
@@ -474,7 +475,7 @@ class StateRecorder:
                     matched_changed_course.files += changed_course.files
         return changed_courses
 
-    def changes_of_new_version(self, current_courses: [Course]) -> [Course]:
+    def changes_of_new_version(self, current_courses: List[Course]) -> List[Course]:
         # all changes are stored inside changed_courses,
         # as a list of changed courses
         changed_courses = []
@@ -499,7 +500,7 @@ class StateRecorder:
 
         return changed_courses
 
-    def get_last_timestamps_per_forum(self) -> {}:
+    def get_last_timestamps_per_forum(self) -> Dict:
         """Returns a dict of timestamps per forum cmid"""
 
         conn = sqlite3.connect(self.db_file)
@@ -522,7 +523,7 @@ class StateRecorder:
 
         return result_dict
 
-    def changes_to_notify(self) -> [Course]:
+    def changes_to_notify(self) -> List[Course]:
         changed_courses = []
 
         conn = sqlite3.connect(self.db_file)
@@ -572,7 +573,7 @@ class StateRecorder:
         conn.close()
         return changed_courses
 
-    def notified(self, courses: [Course]):
+    def notified(self, courses: List[Course]):
         # saves that a notification with the changes where send
 
         conn = sqlite3.connect(self.db_file)
@@ -622,7 +623,7 @@ class StateRecorder:
         conn.commit()
         conn.close()
 
-    def batch_delete_files(self, courses: [Course]):
+    def batch_delete_files(self, courses: List[Course]):
         conn = sqlite3.connect(self.db_file)
         cursor = conn.cursor()
 
@@ -643,7 +644,7 @@ class StateRecorder:
         conn.commit()
         conn.close()
 
-    def batch_delete_files_from_db(self, files: [File]):
+    def batch_delete_files_from_db(self, files: List[File]):
         conn = sqlite3.connect(self.db_file)
         cursor = conn.cursor()
 


### PR DESCRIPTION
This PR follows my suggestion in #163.
I only changed the old type hint to the correct one, so there will be no new types besides `Dict`, `List`, and `Tuple`.
I've also add `.git-blame-ignore-revs` according to [Github Documentation](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)