### PR TITLE
Add Docker workflow to GitHub Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,38 @@
+# This workflows will build and publish a docker image when a new release is created
+name: Publish Docker Image
+
+on:
+  release:
+    types: [created]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Log in to the Container registry
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow which simply builds and publishes a new Docker image every time a new release is created, the same as for the PyPI workflow.

If there is a tag associated with the release, it will be used to tag the image as well. The latest release will always receive the 'latest' tag. If you only want to build docker images from "release" versions, instead of pre-releases and drafts as well, you might want to change the trigger to `released`. The different triggers for the `release` event are documented [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release).

You need to give the Actions runner the "Read and write permissions" (Repository Settings -> Actions -> General) so that the `secrets.GITHUB_TOKEN` has the permissions to publish packages. This is documented [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

Closes #171 