### PR TITLE
Prevent downloader from receiving unsupported gzip encoding

### DIFF
--- a/moodle_dl/downloader/task.py
+++ b/moodle_dl/downloader/task.py
@@ -56,6 +56,7 @@ class Task:
             + ' (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36 MoodleMobile'
         ),
         'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept-Encoding': 'identity',
     }
 
     def __init__(


### PR DESCRIPTION
I've had downloads in a mooodle course fail due to the server defaulting to gzip for some files, which doesn't seem to be supported my Moodle-DL. This makes the downloader explicitly request "identity" encoding, which fixed the problem for me.