### PR TITLE
Fix empty whitelist issue

### DIFF
--- a/moodle_dl/cli/config_wizard.py
+++ b/moodle_dl/cli/config_wizard.py
@@ -148,6 +148,7 @@ class ConfigWizard:
         """
         download_course_ids = self.config.get_download_course_ids()
         dont_download_course_ids = self.config.get_dont_download_course_ids()
+        course_filter_mode = self.config.get_course_filter_mode()
 
         print('')
         Log.info(
@@ -161,7 +162,8 @@ class ConfigWizard:
             + ' on your blacklist it will automatically be downloaded as well. '
         )
         print('')
-        use_whitelist = len(dont_download_course_ids) == 0
+        
+        use_whitelist = course_filter_mode == 'whitelist'
 
         use_whitelist = Cutie.prompt_yes_or_no(
             Log.blue_str('Do you want to create a whitelist or blacklist for your courses?'),
@@ -176,7 +178,7 @@ class ConfigWizard:
             choices.append(f'{int(course.id):5}\t{course.fullname}')
 
             should_download = MoodleService.should_download_course(
-                course.id, download_course_ids, dont_download_course_ids
+                course.id, download_course_ids, dont_download_course_ids, course_filter_mode
             )
             if should_download and use_whitelist:
                 defaults.append(i)
@@ -197,9 +199,11 @@ class ConfigWizard:
                 course_ids.append(course.id)
 
         if use_whitelist:
+            self.config.set_property('course_filter_mode', 'whitelist')
             self.config.set_property('download_course_ids', course_ids)
             self.config.remove_property('dont_download_course_ids')
         elif not use_whitelist:
+            self.config.set_property('course_filter_mode', 'blacklist')
             self.config.set_property('dont_download_course_ids', course_ids)
             self.config.remove_property('download_course_ids')
 
@@ -237,6 +241,7 @@ class ConfigWizard:
         """
         download_course_ids = self.config.get_download_course_ids()
         dont_download_course_ids = self.config.get_dont_download_course_ids()
+        course_filter_mode = self.config.get_course_filter_mode()
 
         self.section_seperator()
         Log.info(
@@ -258,7 +263,7 @@ class ConfigWizard:
             choices.append('None')
 
             for course in courses:
-                if MoodleService.should_download_course(course.id, download_course_ids, dont_download_course_ids):
+                if MoodleService.should_download_course(course.id, download_course_ids, dont_download_course_ids, course_filter_mode):
                     current_course_settings = options_of_courses.get(str(course.id), None)
 
                     # create default settings

--- a/moodle_dl/config.py
+++ b/moodle_dl/config.py
@@ -135,7 +135,7 @@ class ConfigHelper:
 
     def get_course_filter_mode(self) -> str:
         # return the course filter mode ("whitelist" or "blacklist")
-        return self.get_property_or("course_filter_mode", "whitelist")
+        return self.get_property_or("course_filter_mode", "blacklist")
 
     def get_download_course_ids(self) -> str:
         # return a stored list of course ids hat should be downloaded

--- a/moodle_dl/config.py
+++ b/moodle_dl/config.py
@@ -133,6 +133,10 @@ class ConfigHelper:
     def get_do_not_ask_to_save_userid_and_version(self) -> bool:
         return self.get_property_or('do_not_ask_to_save_userid_and_version', False)
 
+    def get_course_filter_mode(self) -> str:
+        # return the course filter mode ("whitelist" or "blacklist")
+        return self.get_property_or("course_filter_mode", "whitelist")
+
     def get_download_course_ids(self) -> str:
         # return a stored list of course ids hat should be downloaded
         return self.get_property_or('download_course_ids', [])

--- a/moodle_dl/moodle/moodle_service.py
+++ b/moodle_dl/moodle/moodle_service.py
@@ -268,6 +268,16 @@ class MoodleService:
         inBlacklist = course_id in dont_download_course_ids
         inWhitelist = course_id in download_course_ids or len(download_course_ids) == 0
 
+        print(
+            "DEBUG should_download_course:",
+            "course_id=", course_id,
+            "download_course_ids=", download_course_ids,
+            "dont_download_course_ids=", dont_download_course_ids,
+            "inWhitelist=", inWhitelist,
+            "inBlacklist=", inBlacklist,
+            "result=", inWhitelist and not inBlacklist,
+        )
+
         return inWhitelist and not inBlacklist
 
     @staticmethod

--- a/moodle_dl/moodle/moodle_service.py
+++ b/moodle_dl/moodle/moodle_service.py
@@ -76,12 +76,13 @@ class MoodleService:
         download_course_ids = self.config.get_download_course_ids()
         download_public_course_ids = self.config.get_download_public_course_ids()
         dont_download_course_ids = self.config.get_dont_download_course_ids()
+        course_filter_mode = self.config.get_course_filter_mode()
 
         courses_list = core_handler.fetch_courses(user_id)
         courses = []
         # Filter unselected courses
         for course in courses_list:
-            if MoodleService.should_download_course(course.id, download_course_ids, dont_download_course_ids):
+            if MoodleService.should_download_course(course.id, download_course_ids, dont_download_course_ids, course_filter_mode):
                 courses.append(course)
 
         public_courses_list = core_handler.fetch_courses_info(download_public_course_ids)
@@ -171,6 +172,7 @@ class MoodleService:
         download_links_in_descriptions = config.get_download_links_in_descriptions()
         exclude_file_extensions = config.get_exclude_file_extensions()
         max_file_size = config.get_max_file_size()
+        course_filter_mode = config.get_course_filter_mode()
 
         download_also_with_cookie = config.get_download_also_with_cookie()
         if cookie_handler is not None:
@@ -181,7 +183,7 @@ class MoodleService:
 
         for course in changes:
             if not MoodleService.should_download_course(
-                course.id, download_course_ids + download_public_course_ids, dont_download_course_ids
+                course.id, download_course_ids + download_public_course_ids, dont_download_course_ids, course_filter_mode
             ):
                 # Filter courses that should not be downloaded
                 continue
@@ -262,23 +264,14 @@ class MoodleService:
 
     @staticmethod
     def should_download_course(
-        course_id: int, download_course_ids: List[int], dont_download_course_ids: List[int]
+        course_id: int, download_course_ids: List[int], dont_download_course_ids: List[int], course_filter_mode: str
     ) -> bool:
-        "Checks if a course is in whitelist and not in blacklist"
-        inBlacklist = course_id in dont_download_course_ids
-        inWhitelist = course_id in download_course_ids or len(download_course_ids) == 0
-
-        print(
-            "DEBUG should_download_course:",
-            "course_id=", course_id,
-            "download_course_ids=", download_course_ids,
-            "dont_download_course_ids=", dont_download_course_ids,
-            "inWhitelist=", inWhitelist,
-            "inBlacklist=", inBlacklist,
-            "result=", inWhitelist and not inBlacklist,
-        )
-
-        return inWhitelist and not inBlacklist
+        "Return whether a course should be downloaded based on the filter mode"
+        
+        if course_filter_mode == "whitelist":
+            return course_id in download_course_ids
+        
+        return course_id not in dont_download_course_ids
 
     @staticmethod
     def should_download_section(section_id: int, dont_download_sections_ids: List[int]) -> bool:


### PR DESCRIPTION
Hello. I've implemented a fix for issue #231  and verified it locally.

### Cause of the issue

The cause of the issue was that: if a `download_course_ids` list was empty, it was interpreted as "allow all courses" instead of "filter all courses". So an empty whitelist behaved like no filtering.

When whitelisting was activated and 0 courses to whitelist were chosen, debug showed that `download_course_ids = []` and that `dont_download_course_ids = []`, and the condition in `should_download_course()` treated this as allowing all courses.

### Changes I made

I changed the config to store the selected filter mode (whitelist / blacklist). I also updated `should_download_course` to use that mode (rather than rely solely on `download_course_ids`).
I set the default filter mode to blacklist to the previous behavior (where all courses are downloaded if no filter is configured).

### Testing

I manually tested all combinations of whitelist / blacklist with empty / non-empty selections. The behavior matches what is expected in each case.

Thanks for your time. I'd be happy to make any adjustments if needed.